### PR TITLE
Enabled the possibility of using the contact status

### DIFF
--- a/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
+++ b/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
@@ -169,6 +169,7 @@ private:
   rviz::FloatProperty *com_shaft_radius_property_;
   rviz::FloatProperty *com_shaft_length_property_;
   rviz::BoolProperty *cop_enable_property_;
+  rviz::BoolProperty *cop_enable_status_property_;
   rviz::ColorProperty *cop_color_property_;
   rviz::FloatProperty *cop_alpha_property_;
   rviz::FloatProperty *cop_radius_property_;
@@ -181,6 +182,7 @@ private:
   rviz::FloatProperty *cmp_alpha_property_;
   rviz::FloatProperty *cmp_radius_property_;
   rviz::BoolProperty *grf_enable_property_;
+  rviz::BoolProperty *grf_enable_status_property_;
   rviz::ColorProperty *grf_color_property_;
   rviz::FloatProperty *grf_alpha_property_;
   rviz::FloatProperty *grf_head_radius_property_;
@@ -188,12 +190,14 @@ private:
   rviz::FloatProperty *grf_shaft_radius_property_;
   rviz::FloatProperty *grf_shaft_length_property_;
   rviz::BoolProperty *support_enable_property_;
+  rviz::BoolProperty *support_enable_status_property_;
   rviz::ColorProperty *support_line_color_property_;
   rviz::FloatProperty *support_line_alpha_property_;
   rviz::FloatProperty *support_line_radius_property_;
   rviz::ColorProperty *support_mesh_color_property_;
   rviz::FloatProperty *support_mesh_alpha_property_;
   rviz::FloatProperty *support_force_threshold_property_;
+  rviz::BoolProperty *friction_cone_enable_status_property_;
   rviz::BoolProperty *friction_cone_enable_property_;
   rviz::ColorProperty *friction_cone_color_property_;
   rviz::FloatProperty *friction_cone_alpha_property_;
@@ -207,6 +211,10 @@ private:
   pinocchio::Model model_;
   pinocchio::Data data_;
   double force_threshold_; //!< Force threshold for detecting active contacts
+  bool use_contact_status_in_cop_;
+  bool use_contact_status_in_grf_;
+  bool use_contact_status_in_support_;
+  bool use_contact_status_in_friction_cone_;
   double weight_;
   double gravity_;
   double friction_mu_;

--- a/src/WholeBodyStateDisplay.cpp
+++ b/src/WholeBodyStateDisplay.cpp
@@ -27,12 +27,13 @@ void linkUpdaterStatusFunction(rviz::StatusLevel level,
 }
 
 WholeBodyStateDisplay::WholeBodyStateDisplay()
-    : initialized_model_(false), force_threshold_(0.), use_contact_status_in_cop_(true),
-      use_contact_status_in_grf_(true), use_contact_status_in_support_(true),
-      use_contact_status_in_friction_cone_(true), weight_(0.),
-      gravity_(9.81), com_real_(true), com_enable_(true), cop_enable_(true),
-      icp_enable_(true), cmp_enable_(true), grf_enable_(true),
-      support_enable_(true), cone_enable_(true) {
+    : initialized_model_(false), force_threshold_(0.),
+      use_contact_status_in_cop_(true), use_contact_status_in_grf_(true),
+      use_contact_status_in_support_(true),
+      use_contact_status_in_friction_cone_(true), weight_(0.), gravity_(9.81),
+      com_real_(true), com_enable_(true), cop_enable_(true), icp_enable_(true),
+      cmp_enable_(true), grf_enable_(true), support_enable_(true),
+      cone_enable_(true) {
   // Category Groups
   robot_category_ = new rviz::Property("Robot", QVariant(), "", this);
   com_category_ = new rviz::Property("Center Of Mass", QVariant(), "", this);
@@ -107,9 +108,10 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   cop_enable_property_ =
       new BoolProperty("Enable", true, "Enable/disable the CoP display",
                        cop_category_, SLOT(updateCoPEnable()), this);
-  cop_enable_status_property_ =
-      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
-                       cop_category_, SLOT(updateCoPEnable()), this);
+  cop_enable_status_property_ = new BoolProperty(
+      "Use Contact Status", true,
+      "Use contact status to detect whether a contact is active", cop_category_,
+      SLOT(updateCoPEnable()), this);
   cop_color_property_ = new rviz::ColorProperty(
       "Color", QColor(204, 41, 204), "Color of a point", cop_category_,
       SLOT(updateCoPColorAndAlpha()), this);
@@ -158,9 +160,10 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   grf_enable_property_ = new BoolProperty(
       "Enable", true, "Enable/disable the contact force display", grf_category_,
       SLOT(updateGRFEnable()), this);
-  grf_enable_status_property_ =
-      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
-                       grf_category_, SLOT(updateGRFEnable()), this);
+  grf_enable_status_property_ = new BoolProperty(
+      "Use Contact Status", true,
+      "Use contact status to detect whether a contact is active", grf_category_,
+      SLOT(updateGRFEnable()), this);
   grf_color_property_ =
       new ColorProperty("Color", QColor(85, 0, 255), "Color to draw the arrow.",
                         grf_category_, SLOT(updateGRFColorAndAlpha()), this);
@@ -186,9 +189,10 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   support_enable_property_ = new BoolProperty(
       "Enable", true, "Enable/disable the support polygon display",
       support_category_, SLOT(updateSupportEnable()), this);
-  support_enable_status_property_ =
-      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
-                       support_category_, SLOT(updateSupportEnable()), this);
+  support_enable_status_property_ = new BoolProperty(
+      "Use Contact Status", true,
+      "Use contact status to detect whether a contact is active",
+      support_category_, SLOT(updateSupportEnable()), this);
   support_line_color_property_ = new ColorProperty(
       "Line Color", QColor(85, 0, 255), "Color to draw the line.",
       support_category_, SLOT(updateSupportLineColorAndAlpha()), this);
@@ -216,9 +220,10 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   friction_cone_enable_property_ = new BoolProperty(
       "Enable", true, "Enable/disable the friction cone display",
       friction_category_, SLOT(updateFrictionConeEnable()), this);
-  friction_cone_enable_status_property_ =
-      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
-                       friction_category_, SLOT(updateFrictionConeEnable()), this);
+  friction_cone_enable_status_property_ = new BoolProperty(
+      "Use Contact Status", true,
+      "Use contact status to detect whether a contact is active",
+      friction_category_, SLOT(updateFrictionConeEnable()), this);
   friction_cone_color_property_ = new ColorProperty(
       "Color", QColor(255, 0, 127), "Color to draw the friction cone.",
       friction_category_, SLOT(updateFrictionConeColorAndAlpha()), this);
@@ -551,7 +556,8 @@ void WholeBodyStateDisplay::updateSupportMeshColorAndAlpha() {
 
 void WholeBodyStateDisplay::updateFrictionConeEnable() {
   cone_enable_ = friction_cone_enable_property_->getBool();
-  use_contact_status_in_friction_cone_ = friction_cone_enable_status_property_->getBool();
+  use_contact_status_in_friction_cone_ =
+      friction_cone_enable_status_property_->getBool();
   if (cones_visual_.size() != 0 && !cone_enable_) {
     cones_visual_.clear();
   }
@@ -678,7 +684,8 @@ void WholeBodyStateDisplay::processWholeBodyState() {
     }
 
     // Building the support polygon
-    if (std::isfinite(contact_pos.x) && std::isfinite(contact_pos.y) && std::isfinite(contact_pos.z)) {
+    if (std::isfinite(contact_pos.x) && std::isfinite(contact_pos.y) &&
+        std::isfinite(contact_pos.z)) {
       Eigen::Quaterniond for_q;
       for_q.setFromTwoVectors(for_ref_dir, for_dir);
       Ogre::Quaternion contact_for_orientation(for_q.w(), for_q.x(), for_q.y(),
@@ -724,7 +731,8 @@ void WholeBodyStateDisplay::processWholeBodyState() {
       } else {
         active_contact_in_support = for_dir.norm() > force_threshold_;
       }
-      if (support_enable_ && active_contact_in_support && contact.type == contact.locomotion) {
+      if (support_enable_ && active_contact_in_support &&
+          contact.type == contact.locomotion) {
         support.push_back(contact_pos);
       }
     }
@@ -739,8 +747,8 @@ void WholeBodyStateDisplay::processWholeBodyState() {
     Eigen::Vector3d cone_dir(contact.surface_normal.x, contact.surface_normal.y,
                              contact.surface_normal.z);
     friction_mu_ = contact.friction_coefficient;
-    if (cone_enable_ && active_contact_in_cone &&
-        cone_dir.norm() != 0 && friction_mu_ != 0) {
+    if (cone_enable_ && active_contact_in_cone && cone_dir.norm() != 0 &&
+        friction_mu_ != 0) {
       Eigen::Vector3d cone_ref_dir = -Eigen::Vector3d::UnitY();
       Eigen::Quaterniond cone_q;
       cone_q.setFromTwoVectors(cone_ref_dir, cone_dir);

--- a/src/WholeBodyStateDisplay.cpp
+++ b/src/WholeBodyStateDisplay.cpp
@@ -27,7 +27,9 @@ void linkUpdaterStatusFunction(rviz::StatusLevel level,
 }
 
 WholeBodyStateDisplay::WholeBodyStateDisplay()
-    : initialized_model_(false), force_threshold_(0.), weight_(0.),
+    : initialized_model_(false), force_threshold_(0.), use_contact_status_in_cop_(true),
+      use_contact_status_in_grf_(true), use_contact_status_in_support_(true),
+      use_contact_status_in_friction_cone_(true), weight_(0.),
       gravity_(9.81), com_real_(true), com_enable_(true), cop_enable_(true),
       icp_enable_(true), cmp_enable_(true), grf_enable_(true),
       support_enable_(true), cone_enable_(true) {
@@ -48,7 +50,7 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
 
   // Robot properties
   robot_enable_property_ =
-      new BoolProperty("Enable", true, "Enable/disable the Target display",
+      new BoolProperty("Enable", true, "Enable/disable the target display",
                        robot_category_, SLOT(updateRobotEnable()), this);
   robot_model_property_ = new StringProperty(
       "Robot Description", "robot_description",
@@ -105,6 +107,9 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   cop_enable_property_ =
       new BoolProperty("Enable", true, "Enable/disable the CoP display",
                        cop_category_, SLOT(updateCoPEnable()), this);
+  cop_enable_status_property_ =
+      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
+                       cop_category_, SLOT(updateCoPEnable()), this);
   cop_color_property_ = new rviz::ColorProperty(
       "Color", QColor(204, 41, 204), "Color of a point", cop_category_,
       SLOT(updateCoPColorAndAlpha()), this);
@@ -153,6 +158,9 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   grf_enable_property_ = new BoolProperty(
       "Enable", true, "Enable/disable the contact force display", grf_category_,
       SLOT(updateGRFEnable()), this);
+  grf_enable_status_property_ =
+      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
+                       grf_category_, SLOT(updateGRFEnable()), this);
   grf_color_property_ =
       new ColorProperty("Color", QColor(85, 0, 255), "Color to draw the arrow.",
                         grf_category_, SLOT(updateGRFColorAndAlpha()), this);
@@ -178,6 +186,9 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   support_enable_property_ = new BoolProperty(
       "Enable", true, "Enable/disable the support polygon display",
       support_category_, SLOT(updateSupportEnable()), this);
+  support_enable_status_property_ =
+      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
+                       support_category_, SLOT(updateSupportEnable()), this);
   support_line_color_property_ = new ColorProperty(
       "Line Color", QColor(85, 0, 255), "Color to draw the line.",
       support_category_, SLOT(updateSupportLineColorAndAlpha()), this);
@@ -205,6 +216,9 @@ WholeBodyStateDisplay::WholeBodyStateDisplay()
   friction_cone_enable_property_ = new BoolProperty(
       "Enable", true, "Enable/disable the friction cone display",
       friction_category_, SLOT(updateFrictionConeEnable()), this);
+  friction_cone_enable_status_property_ =
+      new BoolProperty("Use Contact Status", true, "Use contact status to detect whether a contact is active",
+                       friction_category_, SLOT(updateFrictionConeEnable()), this);
   friction_cone_color_property_ = new ColorProperty(
       "Color", QColor(255, 0, 127), "Color to draw the friction cone.",
       friction_category_, SLOT(updateFrictionConeColorAndAlpha()), this);
@@ -418,6 +432,7 @@ void WholeBodyStateDisplay::updateCoMArrowGeometry() {
 
 void WholeBodyStateDisplay::updateCoPEnable() {
   cop_enable_ = cop_enable_property_->getBool();
+  use_contact_status_in_cop_ = cop_enable_status_property_->getBool();
   if (cop_visual_ && !cop_enable_) {
     cop_visual_.reset();
   }
@@ -475,6 +490,7 @@ void WholeBodyStateDisplay::updateCMPColorAndAlpha() {
 
 void WholeBodyStateDisplay::updateGRFEnable() {
   grf_enable_ = grf_enable_property_->getBool();
+  use_contact_status_in_grf_ = grf_enable_status_property_->getBool();
   if (grf_visual_.size() != 0 && !grf_enable_) {
     grf_visual_.clear();
   }
@@ -504,6 +520,7 @@ void WholeBodyStateDisplay::updateGRFArrowGeometry() {
 
 void WholeBodyStateDisplay::updateSupportEnable() {
   support_enable_ = support_enable_property_->getBool();
+  use_contact_status_in_support_ = support_enable_status_property_->getBool();
   if (support_visual_ && !support_enable_) {
     support_visual_.reset();
   }
@@ -534,6 +551,7 @@ void WholeBodyStateDisplay::updateSupportMeshColorAndAlpha() {
 
 void WholeBodyStateDisplay::updateFrictionConeEnable() {
   cone_enable_ = friction_cone_enable_property_->getBool();
+  use_contact_status_in_friction_cone_ = friction_cone_enable_status_property_->getBool();
   if (cones_visual_.size() != 0 && !cone_enable_) {
     cones_visual_.clear();
   }
@@ -639,7 +657,13 @@ void WholeBodyStateDisplay::processWholeBodyState() {
                             contact.wrench.force.z);
 
     // Updating the center of pressure
-    if (contact.type == 0) {
+    bool active_contact_in_cop = false;
+    if (use_contact_status_in_cop_) {
+      active_contact_in_cop = contact.contact_state == contact.ACTIVE;
+    } else {
+      active_contact_in_cop = for_dir.norm() > force_threshold_;
+    }
+    if (contact.type == contact.locomotion && active_contact_in_cop) {
       cop_pos +=
           contact.wrench.force.z * Eigen::Vector3d(contact.pose.position.x,
                                                    contact.pose.position.y,
@@ -654,8 +678,7 @@ void WholeBodyStateDisplay::processWholeBodyState() {
     }
 
     // Building the support polygon
-    if (for_dir.norm() > force_threshold_ && std::isfinite(contact_pos.x) &&
-        std::isfinite(contact_pos.y) && std::isfinite(contact_pos.z)) {
+    if (std::isfinite(contact_pos.x) && std::isfinite(contact_pos.y) && std::isfinite(contact_pos.z)) {
       Eigen::Quaterniond for_q;
       for_q.setFromTwoVectors(for_ref_dir, for_dir);
       Ogre::Quaternion contact_for_orientation(for_q.w(), for_q.x(), for_q.y(),
@@ -663,7 +686,13 @@ void WholeBodyStateDisplay::processWholeBodyState() {
 
       // We are keeping a vector of visual pointers. This creates the next
       // one and stores it in the vector
-      if (grf_enable_) {
+      bool active_contact_in_grf = false;
+      if (use_contact_status_in_grf_) {
+        active_contact_in_grf = contact.contact_state == contact.ACTIVE;
+      } else {
+        active_contact_in_grf = for_dir.norm() > force_threshold_;
+      }
+      if (grf_enable_ && active_contact_in_grf) {
         boost::shared_ptr<ArrowVisual> arrow;
         arrow.reset(new ArrowVisual(context_->getSceneManager(), scene_node_));
         arrow->setArrow(contact_pos, contact_for_orientation);
@@ -688,16 +717,29 @@ void WholeBodyStateDisplay::processWholeBodyState() {
           grf_visual_.push_back(arrow);
         }
       }
-      if (contact.type == 0 && support_enable_) {
+
+      bool active_contact_in_support = false;
+      if (use_contact_status_in_support_) {
+        active_contact_in_support = contact.contact_state == contact.ACTIVE;
+      } else {
+        active_contact_in_support = for_dir.norm() > force_threshold_;
+      }
+      if (support_enable_ && active_contact_in_support && contact.type == contact.locomotion) {
         support.push_back(contact_pos);
       }
     }
 
     // Building the friction cones
+    bool active_contact_in_cone = false;
+    if (use_contact_status_in_friction_cone_) {
+      active_contact_in_cone = contact.contact_state == contact.ACTIVE;
+    } else {
+      active_contact_in_cone = for_dir.norm() > force_threshold_;
+    }
     Eigen::Vector3d cone_dir(contact.surface_normal.x, contact.surface_normal.y,
                              contact.surface_normal.z);
     friction_mu_ = contact.friction_coefficient;
-    if (cone_enable_ && for_dir.norm() > force_threshold_ &&
+    if (cone_enable_ && active_contact_in_cone &&
         cone_dir.norm() != 0 && friction_mu_ != 0) {
       Eigen::Vector3d cone_ref_dir = -Eigen::Vector3d::UnitY();
       Eigen::Quaterniond cone_q;


### PR DESCRIPTION
We need to detect whether a contact is active or not to display CoP, contact force, support polygon, and friction cone. The current solution is to check whether the norm is not zero; however, this solution might lead to issue in many of our robots as contact forces might be noise or estimated.

Now, with this PR, I enable the possibility of using the `contact_state` field of the whole-body state message. However, it is still possible to use previous method by configuring `Use Contact Status` to false.

Note that this PR is still not based on the new version of the whole-body state message introduced in https://github.com/loco-3d/whole_body_state_msgs/pull/7. Later, I will create another PR. 