### PR TITLE
Display properly the robot and cones for any user-defined fixed frame

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,114 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     119
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<pinocchio/fwd\.hpp>'
+    Priority:        1
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        3
+  - Regex:           '^<.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        4
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ IF(rviz_QT_VERSION VERSION_LESS "5")
     include/whole_body_state_rviz_plugin/LineVisual.h
     include/whole_body_state_rviz_plugin/ArrowVisual.h
     include/whole_body_state_rviz_plugin/PolygonVisual.h
+    include/whole_body_state_rviz_plugin/ConeVisual.h
     include/whole_body_state_rviz_plugin/PinocchioLinkUpdater.h
     include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
     include/whole_body_state_rviz_plugin/WholeBodyTrajectoryDisplay.h
@@ -65,6 +66,7 @@ ELSE()
     include/whole_body_state_rviz_plugin/LineVisual.h
     include/whole_body_state_rviz_plugin/ArrowVisual.h
     include/whole_body_state_rviz_plugin/PolygonVisual.h
+        include/whole_body_state_rviz_plugin/ConeVisual.h
     include/whole_body_state_rviz_plugin/PinocchioLinkUpdater.h
     include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
     include/whole_body_state_rviz_plugin/WholeBodyTrajectoryDisplay.h
@@ -87,6 +89,7 @@ SET(SOURCE_FILES
   src/LineVisual.cpp
   src/ArrowVisual.cpp
   src/PolygonVisual.cpp
+  src/ConeVisual.cpp
   src/PinocchioLinkUpdater.cpp
   src/WholeBodyStateDisplay.cpp
   src/WholeBodyTrajectoryDisplay.cpp

--- a/include/whole_body_state_rviz_plugin/ArrowVisual.h
+++ b/include/whole_body_state_rviz_plugin/ArrowVisual.h
@@ -14,7 +14,7 @@
 namespace Ogre {
 class Vector3;
 class Quaternion;
-} // namespace Ogre
+}  // namespace Ogre
 
 namespace rviz {
 class Arrow;
@@ -30,7 +30,7 @@ namespace whole_body_state_rviz_plugin {
  * the acceleration vector
  */
 class ArrowVisual {
-public:
+ public:
   /**
    * @brief Constructor that creates the visual stuff and puts it into the scene
    * @param scene_manager  Manager the organization and rendering of the scene
@@ -46,8 +46,7 @@ public:
    * @param position     Arrow position
    * @param orientation  Arrow orientation
    */
-  void setArrow(const Ogre::Vector3 &position,
-                const Ogre::Quaternion &orientation);
+  void setArrow(const Ogre::Vector3 &position, const Ogre::Quaternion &orientation);
 
   /**
    * @brief Set the position of the coordinate frame
@@ -77,10 +76,9 @@ public:
    * @param head_length     Length of the arrow's head
    * @param head_diameter   Diameter of the arrow's head
    */
-  void setProperties(float shaft_length, float shaft_diameter,
-                     float head_length, float head_diameter);
+  void setProperties(float shaft_length, float shaft_diameter, float head_length, float head_diameter);
 
-private:
+ private:
   /** @brief The object implementing the arrow */
   rviz::Arrow *arrow_;
 
@@ -93,6 +91,6 @@ private:
   Ogre::SceneManager *scene_manager_;
 };
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
-#endif // WHOLE_BODY_STATE_RVIZ_PLUGIN_ARROW_VISUAL_H
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_ARROW_VISUAL_H

--- a/include/whole_body_state_rviz_plugin/ArrowVisual.h
+++ b/include/whole_body_state_rviz_plugin/ArrowVisual.h
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, University of Edinburgh, Istituto Italiano di Tecnologia
+// Copyright (C) 2020-2021, University of Edinburgh, Istituto Italiano di Tecnologia
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -26,8 +26,7 @@ namespace whole_body_state_rviz_plugin {
  * @class ArrowVisual
  * @brief Visualizes 3d arrow
  * Each instance of ArrowVisual represents the visualization of a single arrow
- * data. Currently it just shows an arrow with the direction and magnitude of
- * the acceleration vector
+ * data. Currently it just shows an arrow with a given direction and magnitude.
  */
 class ArrowVisual {
  public:

--- a/include/whole_body_state_rviz_plugin/ConeVisual.h
+++ b/include/whole_body_state_rviz_plugin/ConeVisual.h
@@ -1,0 +1,93 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2021, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef WHOLE_BODY_STATE_RVIZ_PLUGIN_CONE_VISUAL_H
+#define WHOLE_BODY_STATE_RVIZ_PLUGIN_CONE_VISUAL_H
+
+#include <rviz/properties/quaternion_property.h>
+
+namespace Ogre {
+class Vector3;
+class Quaternion;
+}  // namespace Ogre
+
+namespace rviz {
+class Shape;
+}
+
+namespace whole_body_state_rviz_plugin {
+
+/**
+ * @class ConeVisual
+ * @brief Visualizes 3d cone
+ * Each instance of ConeVisual represents the visualization of a single cone
+ * data. Currently it just shows a cone with a given direction, coefficient and magnitude.
+ */
+class ConeVisual {
+ public:
+  /**
+   * @brief Constructor that creates the visual stuff and puts it into the scene
+   * @param scene_manager  Manager the organization and rendering of the scene
+   * @param parent_node    Represent the cone as node in the scene
+   */
+  ConeVisual(Ogre::SceneManager *scene_manager, Ogre::SceneNode *parent_node);
+
+  /** @brief Destructor that removes the visual stuff from the scene */
+  ~ConeVisual();
+
+  /**
+   * @brief Configure the visual to show the cone
+   * @param position     Cone position
+   * @param orientation  Cone orientation
+   */
+  void setCone(const Ogre::Vector3 &position, const Ogre::Quaternion &orientation);
+
+  /**
+   * @brief Set the position of the coordinate frame
+   * @param position  Frame position
+   */
+  void setFramePosition(const Ogre::Vector3 &position);
+
+  /**
+   * @brief Set the orientation of the coordinate frame
+   * @param orientation Frame orientation
+   */
+  void setFrameOrientation(const Ogre::Quaternion &orientation);
+
+  /**
+   * @brief Set the color and alpha of the visual, which are user-editable
+   * @param r  Red value
+   * @param g  Green value
+   * @param b  Blue value
+   * @param a  Alpha value
+   */
+  void setColor(float r, float g, float b, float a);
+
+  /**
+   * @brief Set the parameters for this cone
+   * @param width    Cone width
+   * @param length  Cone length
+   */
+  void setProperties(float width, float length);
+
+ private:
+  /** @brief The object implementing the cone */
+  rviz::Shape *cone_;
+
+  /** @brief A SceneNode whose pose is set to match the coordinate frame */
+  Ogre::SceneNode *frame_node_;
+
+  /** @brief The SceneManager, kept here only so the destructor can ask it to
+   * destroy the ``frame_node_``.
+   */
+  Ogre::SceneManager *scene_manager_;
+};
+
+}  // namespace whole_body_state_rviz_plugin
+
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_CONE_VISUAL_H

--- a/include/whole_body_state_rviz_plugin/LineVisual.h
+++ b/include/whole_body_state_rviz_plugin/LineVisual.h
@@ -15,7 +15,7 @@
 namespace Ogre {
 class Vector3;
 class Quaternion;
-} // namespace Ogre
+}  // namespace Ogre
 
 namespace rviz {
 class Arrow;
@@ -31,7 +31,7 @@ namespace whole_body_state_rviz_plugin {
  * the initial and final points
  */
 class LineVisual {
-public:
+ public:
   /**
    * @brief Constructor that creates the visual stuff and puts it into the scene
    * @param scene_manager  Manager the organization and rendering of the scene
@@ -47,8 +47,7 @@ public:
    * @param initial_point  Initial point of the line
    * @param final_point    Final point of the line
    */
-  void setArrow(const Ogre::Vector3 &initial_point,
-                const Ogre::Vector3 &final_point);
+  void setArrow(const Ogre::Vector3 &initial_point, const Ogre::Vector3 &final_point);
 
   /**
    * @brief Set the position of the coordinate frame
@@ -77,10 +76,9 @@ public:
    * @param head_length     Length of the arrow's head
    * @param head_diameter   Diameter of the arrow's head
    */
-  void setProperties(float shaft_diameter, float head_length = 0.,
-                     float head_diameter = 0.);
+  void setProperties(float shaft_diameter, float head_length = 0., float head_diameter = 0.);
 
-private:
+ private:
   /** @brief The object implementing the arrow */
   rviz::Arrow *arrow_;
 
@@ -96,6 +94,6 @@ private:
   float distance_;
 };
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
-#endif // WHOLE_BODY_STATE_RVIZ_PLUGIN_LINE_VISUAL_H
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_LINE_VISUAL_H

--- a/include/whole_body_state_rviz_plugin/PinocchioLinkUpdater.h
+++ b/include/whole_body_state_rviz_plugin/PinocchioLinkUpdater.h
@@ -18,29 +18,24 @@
 namespace whole_body_state_rviz_plugin {
 
 class PinocchioLinkUpdater : public rviz::LinkUpdater {
-public:
-  typedef boost::function<void(rviz::StatusLevel, const std::string &,
-                               const std::string &)>
-      StatusCallback;
+ public:
+  typedef boost::function<void(rviz::StatusLevel, const std::string &, const std::string &)> StatusCallback;
 
-  PinocchioLinkUpdater(pinocchio::Model &model, pinocchio::Data &data,
-                       const Eigen::Ref<const Eigen::VectorXd> &q,
+  PinocchioLinkUpdater(pinocchio::Model &model, pinocchio::Data &data, const Eigen::Ref<const Eigen::VectorXd> &q,
                        const StatusCallback &status_cb = StatusCallback());
 
-  bool getLinkTransforms(
-      const std::string &link_name, Ogre::Vector3 &visual_position,
-      Ogre::Quaternion &visual_orientation, Ogre::Vector3 &collision_position,
-      Ogre::Quaternion &collision_orientation) const override;
+  bool getLinkTransforms(const std::string &link_name, Ogre::Vector3 &visual_position,
+                         Ogre::Quaternion &visual_orientation, Ogre::Vector3 &collision_position,
+                         Ogre::Quaternion &collision_orientation) const override;
 
-  void setLinkStatus(rviz::StatusLevel level, const std::string &link_name,
-                     const std::string &text) const override;
+  void setLinkStatus(rviz::StatusLevel level, const std::string &link_name, const std::string &text) const override;
 
-private:
+ private:
   pinocchio::Model &model_;
   pinocchio::Data &data_;
   StatusCallback status_callback_;
 };
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
-#endif // WHOLE_BODY_STATE_RVIZ_PLUGIN_PINOCCHIO_LINK_UPDATER_H
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_PINOCCHIO_LINK_UPDATER_H

--- a/include/whole_body_state_rviz_plugin/PinocchioLinkUpdater.h
+++ b/include/whole_body_state_rviz_plugin/PinocchioLinkUpdater.h
@@ -25,8 +25,7 @@ public:
 
   PinocchioLinkUpdater(pinocchio::Model &model, pinocchio::Data &data,
                        const Eigen::Ref<const Eigen::VectorXd> &q,
-                       const StatusCallback &status_cb = StatusCallback(),
-                       const std::string &tf_prefix = std::string());
+                       const StatusCallback &status_cb = StatusCallback());
 
   bool getLinkTransforms(
       const std::string &link_name, Ogre::Vector3 &visual_position,
@@ -40,7 +39,6 @@ private:
   pinocchio::Model &model_;
   pinocchio::Data &data_;
   StatusCallback status_callback_;
-  std::string tf_prefix_;
 };
 
 } // namespace whole_body_state_rviz_plugin

--- a/include/whole_body_state_rviz_plugin/PointVisual.h
+++ b/include/whole_body_state_rviz_plugin/PointVisual.h
@@ -12,7 +12,7 @@
 namespace Ogre {
 class Vector3;
 class Quaternion;
-} // namespace Ogre
+}  // namespace Ogre
 
 namespace rviz {
 class Shape;
@@ -27,7 +27,7 @@ namespace whole_body_state_rviz_plugin {
  * Ogre::Vector3 data. Currently it just shows a sphere in the point position
  */
 class PointVisual {
-public:
+ public:
   /**
    * @brief Constructor that creates the visual stuff and puts it into the scene
    * @param scene_manager  Manager the organization and rendering of the scene
@@ -71,7 +71,7 @@ public:
    */
   void setRadius(float r);
 
-private:
+ private:
   /** @brief The object implementing the point circle */
   rviz::Shape *point_;
 
@@ -87,6 +87,6 @@ private:
   float radius_;
 };
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
-#endif // WHOLE_BODY_STATE_RVIZ_PLUGIN_POINT_VISUAL_H
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_POINT_VISUAL_H

--- a/include/whole_body_state_rviz_plugin/PolygonVisual.h
+++ b/include/whole_body_state_rviz_plugin/PolygonVisual.h
@@ -16,13 +16,12 @@
 namespace Ogre {
 class Vector3;
 class Quaternion;
-} // namespace Ogre
+}  // namespace Ogre
 
 namespace whole_body_state_rviz_plugin {
 
 struct Triangle {
-  Triangle(unsigned int _v1, unsigned int _v2, unsigned int _v3)
-      : v1(_v1), v2(_v2), v3(_v3) {}
+  Triangle(unsigned int _v1, unsigned int _v2, unsigned int _v3) : v1(_v1), v2(_v2), v3(_v3) {}
 
   unsigned int v1;
   unsigned int v2;
@@ -36,14 +35,13 @@ struct Triangle {
  * polygons data. Currently it just shows a set of polygons
  */
 class PolygonVisual {
-public:
+ public:
   /**
    * @brief Constructor that creates the visual stuff and puts it into the scene
    * @param scene_manager  Manager the organization and rendering of the scene
    * @param parent_node    Represent the arrow as node in the scene
    */
-  PolygonVisual(Ogre::SceneManager *scene_manager,
-                Ogre::SceneNode *parent_node);
+  PolygonVisual(Ogre::SceneManager *scene_manager, Ogre::SceneNode *parent_node);
 
   /** @brief Destructor that removes the visual stuff from the scene */
   ~PolygonVisual();
@@ -90,13 +88,12 @@ public:
    */
   void setLineRadius(float scale);
 
-private:
+ private:
   /** @brief The object implementing the polygon mesh */
   boost::shared_ptr<rviz::MeshShape> mesh_;
 
   /** @brief The object implementing the lines */
-  std::vector<boost::shared_ptr<whole_body_state_rviz_plugin::LineVisual>>
-      line_;
+  std::vector<boost::shared_ptr<whole_body_state_rviz_plugin::LineVisual>> line_;
 
   /** @brief A SceneNode whose pose is set to match the coordinate frame */
   Ogre::SceneNode *frame_node_;
@@ -107,6 +104,6 @@ private:
   Ogre::SceneManager *scene_manager_;
 };
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
-#endif // WHOLE_BODY_STATE_RVIZ_PLUGIN_POLYGON_VISUAL_H
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_POLYGON_VISUAL_H

--- a/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
+++ b/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
@@ -35,7 +35,7 @@ class ColorProperty;
 class FloatProperty;
 class IntProperty;
 class Shape;
-} // namespace rviz
+}  // namespace rviz
 
 namespace whole_body_state_rviz_plugin {
 
@@ -43,10 +43,9 @@ namespace whole_body_state_rviz_plugin {
  * @class WholeBodyStateDisplay
  * @brief Displays a whole_body_state_msgs::WholeBodyState message
  */
-class WholeBodyStateDisplay
-    : public rviz::MessageFilterDisplay<whole_body_state_msgs::WholeBodyState> {
+class WholeBodyStateDisplay : public rviz::MessageFilterDisplay<whole_body_state_msgs::WholeBodyState> {
   Q_OBJECT
-public:
+ public:
   /** @brief Constructor function */
   WholeBodyStateDisplay();
 
@@ -74,13 +73,12 @@ public:
    * @param const whole_body_state_msgs::WholeBodyState::ConstPtr& Whole-body
    * state msg
    */
-  void processMessage(
-      const whole_body_state_msgs::WholeBodyState::ConstPtr &msg) override;
+  void processMessage(const whole_body_state_msgs::WholeBodyState::ConstPtr &msg) override;
 
   /** @brief render callback */
   void update(float wall_dt, float ros_dt) override;
 
-private Q_SLOTS:
+ private Q_SLOTS:
   /**@{*/
   /** Helper function to apply color and alpha to all visuals.
    * Set the current color and alpha values for each visual */
@@ -110,7 +108,7 @@ private Q_SLOTS:
   void updateFrictionConeGeometry();
   /**@}*/
 
-private:
+ private:
   void processWholeBodyState();
 
   /** @brief Loads a URDF from the ros-param named by our
@@ -125,8 +123,8 @@ private:
   /** @brief Whole-body state message */
   whole_body_state_msgs::WholeBodyState::ConstPtr msg_;
 
-  bool has_new_msg_; ///< Callback sets this to tell our update function
-                     ///< it needs to update the model
+  bool has_new_msg_;  ///< Callback sets this to tell our update function
+                      ///< it needs to update the model
 
   /**@{*/
   /** Properties to show on side panel */
@@ -211,7 +209,7 @@ private:
   bool initialized_model_;
   pinocchio::Model model_;
   pinocchio::Data data_;
-  double force_threshold_; //!< Force threshold for detecting active contacts
+  double force_threshold_;  //!< Force threshold for detecting active contacts
   bool use_contact_status_in_cop_;
   bool use_contact_status_in_grf_;
   bool use_contact_status_in_support_;
@@ -221,9 +219,9 @@ private:
   double friction_mu_;
   /**@}*/
 
-  enum CoMStyle { REAL, PROJECTED }; //!< CoM visualization style
-  bool com_real_; //!< Label to indicates the type of CoM display (real or
-                  //!< projected)
+  enum CoMStyle { REAL, PROJECTED };  //!< CoM visualization style
+  bool com_real_;                     //!< Label to indicates the type of CoM display (real or
+                                      //!< projected)
 
   /**@{*/
   /** Flag that indicates if the category are enable */
@@ -238,6 +236,6 @@ private:
   /**@}*/
 };
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
-#endif // WHOLE_BODY_STATE_RVIZ_PLUGIN_WHOLE_BODY_STATE_DISPLAY_H
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_WHOLE_BODY_STATE_DISPLAY_H

--- a/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
+++ b/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
@@ -23,6 +23,7 @@
 #include "whole_body_state_rviz_plugin/ArrowVisual.h"
 #include "whole_body_state_rviz_plugin/PointVisual.h"
 #include "whole_body_state_rviz_plugin/PolygonVisual.h"
+#include "whole_body_state_rviz_plugin/ConeVisual.h"
 
 namespace Ogre {
 class SceneNode;
@@ -148,7 +149,7 @@ class WholeBodyStateDisplay : public rviz::MessageFilterDisplay<whole_body_state
   boost::shared_ptr<PointVisual> icp_visual_;
   std::vector<boost::shared_ptr<ArrowVisual>> grf_visual_;
   boost::shared_ptr<PolygonVisual> support_visual_;
-  std::vector<boost::shared_ptr<rviz::Shape>> cones_visual_;
+  std::vector<boost::shared_ptr<ConeVisual>> cones_visual_;
   /**@}*/
 
   /**@{*/

--- a/include/whole_body_state_rviz_plugin/WholeBodyTrajectoryDisplay.h
+++ b/include/whole_body_state_rviz_plugin/WholeBodyTrajectoryDisplay.h
@@ -37,7 +37,7 @@ class BillboardLine;
 class VectorProperty;
 class Axes;
 
-} // namespace rviz
+}  // namespace rviz
 
 namespace whole_body_state_rviz_plugin {
 
@@ -45,11 +45,9 @@ namespace whole_body_state_rviz_plugin {
  * @class WholeBodyTrajectoryDisplay
  * @brief Displays a whole_body_state_msgs::WholeBodyTrajectory message
  */
-class WholeBodyTrajectoryDisplay
-    : public rviz::MessageFilterDisplay<
-          whole_body_state_msgs::WholeBodyTrajectory> {
+class WholeBodyTrajectoryDisplay : public rviz::MessageFilterDisplay<whole_body_state_msgs::WholeBodyTrajectory> {
   Q_OBJECT
-public:
+ public:
   /** @brief Constructor function */
   WholeBodyTrajectoryDisplay();
 
@@ -77,13 +75,12 @@ public:
    * @param const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr&
    * Whole-body trajectory msg
    */
-  void processMessage(
-      const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr &msg) override;
+  void processMessage(const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr &msg) override;
 
   /** @brief render callback */
   void update(float wall_dt, float ros_dt) override;
 
-private Q_SLOTS:
+ private Q_SLOTS:
   /**@{*/
   /** Helper functions to apply color and alpha to all visuals.
    * Set the current color and alpha values for each visual */
@@ -100,13 +97,11 @@ private Q_SLOTS:
   void updateContactEnable();
   void updateContactStyle();
   void updateContactLineProperties();
-  void pushBackCoMAxes(const Ogre::Vector3 &axes_position,
-                       const Ogre::Quaternion &axes_orientation);
-  void pushBackContactAxes(const Ogre::Vector3 &axes_position,
-                           const Ogre::Quaternion &axes_orientation);
+  void pushBackCoMAxes(const Ogre::Vector3 &axes_position, const Ogre::Quaternion &axes_orientation);
+  void pushBackContactAxes(const Ogre::Vector3 &axes_position, const Ogre::Quaternion &axes_orientation);
   /**@}*/
 
-private:
+ private:
   /**@{*/
   /** Process the trajectories */
   void processTargetPosture();
@@ -126,8 +121,8 @@ private:
   /** @brief Whole-body trajectory message */
   whole_body_state_msgs::WholeBodyTrajectory::ConstPtr msg_;
 
-  bool has_new_msg_; ///< Callback sets this to tell our update function
-                     ///< it needs to update the model
+  bool has_new_msg_;  ///< Callback sets this to tell our update function
+                      ///< it needs to update the model
 
   /**@{*/
   /** Properties to show on side panel */
@@ -199,6 +194,6 @@ private:
   /**@}*/
 };
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
-#endif // WHOLE_BODY_STATE_RVIZ_PLUGIN_WHOLE_BODY_TRAJECTORY_DISPLAY_H
+#endif  // WHOLE_BODY_STATE_RVIZ_PLUGIN_WHOLE_BODY_TRAJECTORY_DISPLAY_H

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>whole_body_state_rviz_plugin</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>
     Visualization plugins of whole-body state messages
   </description>

--- a/src/ArrowVisual.cpp
+++ b/src/ArrowVisual.cpp
@@ -16,8 +16,7 @@
 
 namespace whole_body_state_rviz_plugin {
 
-ArrowVisual::ArrowVisual(Ogre::SceneManager *scene_manager,
-                         Ogre::SceneNode *parent_node) {
+ArrowVisual::ArrowVisual(Ogre::SceneManager *scene_manager, Ogre::SceneNode *parent_node) {
   scene_manager_ = scene_manager;
 
   // Ogre::SceneNode s form a tree, with each node storing the transform
@@ -40,26 +39,20 @@ ArrowVisual::~ArrowVisual() {
   scene_manager_->destroySceneNode(frame_node_);
 }
 
-void ArrowVisual::setArrow(const Ogre::Vector3 &position,
-                           const Ogre::Quaternion &orientation) {
+void ArrowVisual::setArrow(const Ogre::Vector3 &position, const Ogre::Quaternion &orientation) {
   arrow_->setPosition(position);
   arrow_->setOrientation(orientation);
 }
 
-void ArrowVisual::setFramePosition(const Ogre::Vector3 &position) {
-  frame_node_->setPosition(position);
-}
+void ArrowVisual::setFramePosition(const Ogre::Vector3 &position) { frame_node_->setPosition(position); }
 
 void ArrowVisual::setFrameOrientation(const Ogre::Quaternion &orientation) {
   frame_node_->setOrientation(orientation);
 }
 
-void ArrowVisual::setColor(float r, float g, float b, float a) {
-  arrow_->setColor(r, g, b, a);
-}
+void ArrowVisual::setColor(float r, float g, float b, float a) { arrow_->setColor(r, g, b, a); }
 
-void ArrowVisual::setProperties(float shaft_length, float shaft_diameter,
-                                float head_length, float head_diameter) {
+void ArrowVisual::setProperties(float shaft_length, float shaft_diameter, float head_length, float head_diameter) {
   if (!std::isfinite(shaft_length)) {
     ROS_WARN_STREAM("Shaft length is not finite: " << shaft_length);
     return;
@@ -79,4 +72,4 @@ void ArrowVisual::setProperties(float shaft_length, float shaft_diameter,
   arrow_->set(shaft_length, shaft_diameter, head_length, head_diameter);
 }
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin

--- a/src/ConeVisual.cpp
+++ b/src/ConeVisual.cpp
@@ -1,0 +1,66 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2021, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreVector3.h>
+
+#include <ros/console.h>
+#include <rviz/ogre_helpers/shape.h>
+#include <whole_body_state_rviz_plugin/ConeVisual.h>
+
+namespace whole_body_state_rviz_plugin {
+
+ConeVisual::ConeVisual(Ogre::SceneManager *scene_manager, Ogre::SceneNode *parent_node) {
+  scene_manager_ = scene_manager;
+
+  // Ogre::SceneNode s form a tree, with each node storing the transform
+  // (position and orientation) of itself relative to its parent. Ogre does
+  // the math of combining those transforms when it is time to render.
+  // Here we create a node to store the pose of the Point's header frame
+  // relative to the RViz fixed frame.
+  frame_node_ = parent_node->createChildSceneNode();
+
+  // We create the arrow object within the frame node so that we can set its
+  // position and direction relative to its header frame.
+  cone_ = new rviz::Shape(rviz::Shape::Cone, scene_manager_, frame_node_);
+}
+
+ConeVisual::~ConeVisual() {
+  // Delete the arrow to make it disappear.
+  delete cone_;
+
+  // Destroy the frame node since we don't need it anymore.
+  scene_manager_->destroySceneNode(frame_node_);
+}
+
+void ConeVisual::setCone(const Ogre::Vector3 &position, const Ogre::Quaternion &orientation) {
+  cone_->setPosition(position);
+  cone_->setOrientation(orientation);
+}
+
+void ConeVisual::setFramePosition(const Ogre::Vector3 &position) { frame_node_->setPosition(position); }
+
+void ConeVisual::setFrameOrientation(const Ogre::Quaternion &orientation) { frame_node_->setOrientation(orientation); }
+
+void ConeVisual::setColor(float r, float g, float b, float a) { cone_->setColor(r, g, b, a); }
+
+void ConeVisual::setProperties(float width, float length) {
+  if (!std::isfinite(width)) {
+    ROS_WARN_STREAM("Cone length is not finite: " << width);
+    return;
+  }
+  if (!std::isfinite(length)) {
+    ROS_WARN_STREAM("Cone length is not finite: " << length);
+    return;
+  }
+  cone_->setScale(Ogre::Vector3(width, length, width));
+  cone_->setOffset(Ogre::Vector3(0., -0.5, 0.));
+}
+
+}  // namespace whole_body_state_rviz_plugin

--- a/src/LineVisual.cpp
+++ b/src/LineVisual.cpp
@@ -15,9 +15,7 @@
 
 namespace whole_body_state_rviz_plugin {
 
-LineVisual::LineVisual(Ogre::SceneManager *scene_manager,
-                       Ogre::SceneNode *parent_node)
-    : distance_(0.) {
+LineVisual::LineVisual(Ogre::SceneManager *scene_manager, Ogre::SceneNode *parent_node) : distance_(0.) {
   scene_manager_ = scene_manager;
 
   // Ogre::SceneNode s form a tree, with each node storing the transform
@@ -39,37 +37,27 @@ LineVisual::~LineVisual() {
   scene_manager_->destroySceneNode(frame_node_);
 }
 
-void LineVisual::setArrow(const Ogre::Vector3 &initial_point,
-                          const Ogre::Vector3 &final_point) {
+void LineVisual::setArrow(const Ogre::Vector3 &initial_point, const Ogre::Vector3 &final_point) {
   arrow_->setPosition(initial_point);
   Eigen::Vector3d ref_dir = -Eigen::Vector3d::UnitZ();
-  Eigen::Vector3d arrow_dir(final_point.x - initial_point.x,
-                            final_point.y - initial_point.y,
+  Eigen::Vector3d arrow_dir(final_point.x - initial_point.x, final_point.y - initial_point.y,
                             final_point.z - initial_point.z);
 
   Eigen::Quaterniond arrow_q;
   arrow_q.setFromTwoVectors(ref_dir, arrow_dir);
-  Ogre::Quaternion orientation(arrow_q.w(), arrow_q.x(), arrow_q.y(),
-                               arrow_q.z());
+  Ogre::Quaternion orientation(arrow_q.w(), arrow_q.x(), arrow_q.y(), arrow_q.z());
   arrow_->setOrientation(orientation);
   distance_ = arrow_dir.norm();
 }
 
-void LineVisual::setFramePosition(const Ogre::Vector3 &position) {
-  frame_node_->setPosition(position);
-}
+void LineVisual::setFramePosition(const Ogre::Vector3 &position) { frame_node_->setPosition(position); }
 
-void LineVisual::setFrameOrientation(const Ogre::Quaternion &orientation) {
-  frame_node_->setOrientation(orientation);
-}
+void LineVisual::setFrameOrientation(const Ogre::Quaternion &orientation) { frame_node_->setOrientation(orientation); }
 
-void LineVisual::setColor(float r, float g, float b, float a) {
-  arrow_->setColor(r, g, b, a);
-}
+void LineVisual::setColor(float r, float g, float b, float a) { arrow_->setColor(r, g, b, a); }
 
-void LineVisual::setProperties(float shaft_diameter, float head_length,
-                               float head_diameter) {
+void LineVisual::setProperties(float shaft_diameter, float head_length, float head_diameter) {
   arrow_->set(distance_, shaft_diameter, head_length, head_diameter);
 }
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin

--- a/src/PinocchioLinkUpdater.cpp
+++ b/src/PinocchioLinkUpdater.cpp
@@ -17,24 +17,21 @@
 
 namespace whole_body_state_rviz_plugin {
 
-PinocchioLinkUpdater::PinocchioLinkUpdater(
-    pinocchio::Model &model, pinocchio::Data &data,
-    const Eigen::Ref<const Eigen::VectorXd> &q, const StatusCallback &status_cb)
+PinocchioLinkUpdater::PinocchioLinkUpdater(pinocchio::Model &model, pinocchio::Data &data,
+                                           const Eigen::Ref<const Eigen::VectorXd> &q, const StatusCallback &status_cb)
     : model_(model), data_(data), status_callback_(status_cb) {
   pinocchio::framesForwardKinematics(model_, data_, q);
 }
 
-bool PinocchioLinkUpdater::getLinkTransforms(
-    const std::string &link_name, Ogre::Vector3 &visual_position,
-    Ogre::Quaternion &visual_orientation, Ogre::Vector3 &collision_position,
-    Ogre::Quaternion &collision_orientation) const {
+bool PinocchioLinkUpdater::getLinkTransforms(const std::string &link_name, Ogre::Vector3 &visual_position,
+                                             Ogre::Quaternion &visual_orientation, Ogre::Vector3 &collision_position,
+                                             Ogre::Quaternion &collision_orientation) const {
   if (model_.existFrame(link_name)) {
     pinocchio::FrameIndex frameId = model_.getFrameId(link_name);
     const Eigen::Vector3d &translation = data_.oMf[frameId].translation();
     Eigen::Quaterniond quaternion(data_.oMf[frameId].rotation());
     Ogre::Vector3 position(translation[0], translation[1], translation[2]);
-    Ogre::Quaternion orientation(quaternion.w(), quaternion.x(), quaternion.y(),
-                                 quaternion.z());
+    Ogre::Quaternion orientation(quaternion.w(), quaternion.x(), quaternion.y(), quaternion.z());
 
     // Collision/visual transforms are the same in this case
     visual_position = position;
@@ -51,12 +48,11 @@ bool PinocchioLinkUpdater::getLinkTransforms(
   return true;
 }
 
-void PinocchioLinkUpdater::setLinkStatus(rviz::StatusLevel level,
-                                         const std::string &link_name,
+void PinocchioLinkUpdater::setLinkStatus(rviz::StatusLevel level, const std::string &link_name,
                                          const std::string &text) const {
   if (status_callback_) {
     status_callback_(level, link_name, text);
   }
 }
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin

--- a/src/PinocchioLinkUpdater.cpp
+++ b/src/PinocchioLinkUpdater.cpp
@@ -19,10 +19,8 @@ namespace whole_body_state_rviz_plugin {
 
 PinocchioLinkUpdater::PinocchioLinkUpdater(
     pinocchio::Model &model, pinocchio::Data &data,
-    const Eigen::Ref<const Eigen::VectorXd> &q, const StatusCallback &status_cb,
-    const std::string &tf_prefix)
-    : model_(model), data_(data), status_callback_(status_cb),
-      tf_prefix_(tf_prefix) {
+    const Eigen::Ref<const Eigen::VectorXd> &q, const StatusCallback &status_cb)
+    : model_(model), data_(data), status_callback_(status_cb) {
   pinocchio::framesForwardKinematics(model_, data_, q);
 }
 

--- a/src/PointVisual.cpp
+++ b/src/PointVisual.cpp
@@ -15,9 +15,7 @@
 
 namespace whole_body_state_rviz_plugin {
 
-PointVisual::PointVisual(Ogre::SceneManager *scene_manager,
-                         Ogre::SceneNode *parent_node)
-    : radius_(0.) {
+PointVisual::PointVisual(Ogre::SceneManager *scene_manager, Ogre::SceneNode *parent_node) : radius_(0.) {
   scene_manager_ = scene_manager;
 
   // Ogre::SceneNode s form a tree, with each node storing the transform
@@ -49,18 +47,14 @@ void PointVisual::setPoint(const Ogre::Vector3 &point) {
   point_->setPosition(point);
 }
 
-void PointVisual::setFramePosition(const Ogre::Vector3 &position) {
-  frame_node_->setPosition(position);
-}
+void PointVisual::setFramePosition(const Ogre::Vector3 &position) { frame_node_->setPosition(position); }
 
 void PointVisual::setFrameOrientation(const Ogre::Quaternion &orientation) {
   frame_node_->setOrientation(orientation);
 }
 
-void PointVisual::setColor(float r, float g, float b, float a) {
-  point_->setColor(r, g, b, a);
-}
+void PointVisual::setColor(float r, float g, float b, float a) { point_->setColor(r, g, b, a); }
 
 void PointVisual::setRadius(float r) { radius_ = r; }
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin

--- a/src/PolygonVisual.cpp
+++ b/src/PolygonVisual.cpp
@@ -15,8 +15,7 @@
 
 namespace whole_body_state_rviz_plugin {
 
-PolygonVisual::PolygonVisual(Ogre::SceneManager *scene_manager,
-                             Ogre::SceneNode *parent_node) {
+PolygonVisual::PolygonVisual(Ogre::SceneManager *scene_manager, Ogre::SceneNode *parent_node) {
   scene_manager_ = scene_manager;
 
   // Ogre::SceneNode s form a tree, with each node storing the transform
@@ -45,8 +44,7 @@ void PolygonVisual::setVertices(std::vector<Ogre::Vector3> &vertices) {
   // Visualization of the lines
   line_.clear();
   unsigned int num_line = 0;
-  for (unsigned int i = 1; i < num_vertex; i++)
-    num_line += num_vertex - i;
+  for (unsigned int i = 1; i < num_vertex; i++) num_line += num_vertex - i;
   line_.resize(num_line);
 
   unsigned int counter = 0;
@@ -56,8 +54,7 @@ void PolygonVisual::setVertices(std::vector<Ogre::Vector3> &vertices) {
     for (unsigned int i = current_it; i < num_vertex - 1; i++) {
       // We create the line object within the frame node so that we can
       // set its position and direction relative to its header frame.
-      line_[counter].reset(new whole_body_state_rviz_plugin::LineVisual(
-          scene_manager_, frame_node_));
+      line_[counter].reset(new whole_body_state_rviz_plugin::LineVisual(scene_manager_, frame_node_));
 
       line_[counter]->setArrow(vertices[current_it], vertices[i + 1]);
 
@@ -74,13 +71,11 @@ void PolygonVisual::setVertices(std::vector<Ogre::Vector3> &vertices) {
 
     // Adding the vertices
     Ogre::Vector3 normal(0., 0., 1.);
-    for (unsigned int i = 0; i < num_vertex; ++i)
-      mesh_->addVertex(vertices[i], normal);
+    for (unsigned int i = 0; i < num_vertex; ++i) mesh_->addVertex(vertices[i], normal);
 
     // Adding the actual triangle
     for (unsigned int i = 0; i < num_vertex; i++) {
-      mesh_->addTriangle(i % num_vertex, (i + 1) % num_vertex,
-                         (i + 2) % num_vertex);
+      mesh_->addTriangle(i % num_vertex, (i + 1) % num_vertex, (i + 2) % num_vertex);
     }
     mesh_->endTriangles();
   }
@@ -103,9 +98,7 @@ void PolygonVisual::setLineColor(float r, float g, float b, float a) {
   }
 }
 
-void PolygonVisual::setMeshColor(float r, float g, float b, float a) {
-  mesh_->setColor(r, g, b, a);
-}
+void PolygonVisual::setMeshColor(float r, float g, float b, float a) { mesh_->setColor(r, g, b, a); }
 
 void PolygonVisual::setLineRadius(float radius) {
   unsigned int num_line = line_.size();
@@ -114,4 +107,4 @@ void PolygonVisual::setLineRadius(float radius) {
   }
 }
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin

--- a/src/WholeBodyStateDisplay.cpp
+++ b/src/WholeBodyStateDisplay.cpp
@@ -624,6 +624,8 @@ void WholeBodyStateDisplay::processWholeBodyState() {
     q(0) = msg_->centroidal.com_position.x - data_.com[0](0);
     q(1) = msg_->centroidal.com_position.y - data_.com[0](1);
     q(2) = msg_->centroidal.com_position.z - data_.com[0](2);
+    robot_->setPosition(position);
+    robot_->setOrientation(orientation);
     robot_->update(PinocchioLinkUpdater(
         model_, data_, q,
         boost::bind(linkUpdaterStatusFunction, _1, _2, _3, this)));

--- a/src/WholeBodyTrajectoryDisplay.cpp
+++ b/src/WholeBodyTrajectoryDisplay.cpp
@@ -20,17 +20,18 @@ using namespace rviz;
 
 namespace whole_body_state_rviz_plugin {
 
-void linkUpdaterStatusFunction(rviz::StatusLevel level,
-                               const std::string &link_name,
-                               const std::string &text,
+void linkUpdaterStatusFunction(rviz::StatusLevel level, const std::string &link_name, const std::string &text,
                                WholeBodyTrajectoryDisplay *display) {
-  display->setStatus(level, QString::fromStdString(link_name),
-                     QString::fromStdString(text));
+  display->setStatus(level, QString::fromStdString(link_name), QString::fromStdString(text));
 }
 
 WholeBodyTrajectoryDisplay::WholeBodyTrajectoryDisplay()
-    : has_new_msg_(false), weight_(0.), target_enable_(true), com_enable_(true),
-      com_axes_enable_(true), contact_enable_(true),
+    : has_new_msg_(false),
+      weight_(0.),
+      target_enable_(true),
+      com_enable_(true),
+      com_axes_enable_(true),
+      contact_enable_(true),
       contact_axes_enable_(true) {
   // Category Groups
   target_category_ = new rviz::Property("Target", QVariant(), "", this);
@@ -38,104 +39,84 @@ WholeBodyTrajectoryDisplay::WholeBodyTrajectoryDisplay()
   contact_category_ = new rviz::Property("End-Effector", QVariant(), "", this);
 
   // Target properties
-  target_enable_property_ =
-      new BoolProperty("Enable", true, "Enable/disable the Target display",
-                       target_category_, SLOT(updateTargetEnable()), this);
+  target_enable_property_ = new BoolProperty("Enable", true, "Enable/disable the Target display", target_category_,
+                                             SLOT(updateTargetEnable()), this);
   robot_description_property_ = new StringProperty(
-      "Robot Description", "robot_description",
-      "Name of the parameter to search for to load the robot description.",
+      "Robot Description", "robot_description", "Name of the parameter to search for to load the robot description.",
       target_category_, SLOT(updateRobotDescription()), this);
   robot_visual_enabled_property_ =
-      new Property("Robot Visual", true,
-                   "Whether to display the visual representation of the robot.",
+      new Property("Robot Visual", true, "Whether to display the visual representation of the robot.",
                    target_category_, SLOT(updateRobotVisualVisible()), this);
-  robot_collision_enabled_property_ = new Property(
-      "Robot Collision", false,
-      "Whether to display the collision representation of the robot.",
-      target_category_, SLOT(updateRobotCollisionVisible()), this);
-  robot_alpha_property_ = new FloatProperty(
-      "Robot Alpha", 0.2, "Amount of transparency to apply to the links.",
-      target_category_, SLOT(updateRobotAlpha()), this);
+  robot_collision_enabled_property_ =
+      new Property("Robot Collision", false, "Whether to display the collision representation of the robot.",
+                   target_category_, SLOT(updateRobotCollisionVisible()), this);
+  robot_alpha_property_ = new FloatProperty("Robot Alpha", 0.2, "Amount of transparency to apply to the links.",
+                                            target_category_, SLOT(updateRobotAlpha()), this);
   robot_alpha_property_->setMin(0.0);
   robot_alpha_property_->setMax(1.0);
-  force_color_property_ = new ColorProperty(
-      "Force Color", QColor(85, 0, 255), "Color to draw the arrow.",
-      target_category_, SLOT(updateForceColorAndAlpha()), this);
-  force_alpha_property_ = new FloatProperty(
-      "Force Alpha", 0.2, "Amount of transparency to apply to the arrow.",
-      target_category_, SLOT(updateForceColorAndAlpha()), this);
+  force_color_property_ = new ColorProperty("Force Color", QColor(85, 0, 255), "Color to draw the arrow.",
+                                            target_category_, SLOT(updateForceColorAndAlpha()), this);
+  force_alpha_property_ = new FloatProperty("Force Alpha", 0.2, "Amount of transparency to apply to the arrow.",
+                                            target_category_, SLOT(updateForceColorAndAlpha()), this);
   force_alpha_property_->setMin(0);
   force_alpha_property_->setMax(1);
-  force_shaft_length_property_ = new FloatProperty(
-      "Force Shaft Length", 0.8, "Length of the arrow's shaft, in meters.",
-      target_category_, SLOT(updateForceArrowGeometry()), this);
-  force_shaft_radius_property_ = new FloatProperty(
-      "Force Shaft Radius", 0.02, "Radius of the arrow's shaft, in meters.",
-      target_category_, SLOT(updateForceArrowGeometry()), this);
-  force_head_length_property_ = new FloatProperty(
-      "Force Head Length", 0.08, "Length of the arrow's head, in meters.",
-      target_category_, SLOT(updateForceArrowGeometry()), this);
-  force_head_radius_property_ = new FloatProperty(
-      "Force Head Radius", 0.04, "Radius of the arrow's head, in meters.",
-      target_category_, SLOT(updateForceArrowGeometry()), this);
+  force_shaft_length_property_ =
+      new FloatProperty("Force Shaft Length", 0.8, "Length of the arrow's shaft, in meters.", target_category_,
+                        SLOT(updateForceArrowGeometry()), this);
+  force_shaft_radius_property_ =
+      new FloatProperty("Force Shaft Radius", 0.02, "Radius of the arrow's shaft, in meters.", target_category_,
+                        SLOT(updateForceArrowGeometry()), this);
+  force_head_length_property_ = new FloatProperty("Force Head Length", 0.08, "Length of the arrow's head, in meters.",
+                                                  target_category_, SLOT(updateForceArrowGeometry()), this);
+  force_head_radius_property_ = new FloatProperty("Force Head Radius", 0.04, "Radius of the arrow's head, in meters.",
+                                                  target_category_, SLOT(updateForceArrowGeometry()), this);
 
   // Center of Mass trajectory properties
   com_enable_property_ =
-      new BoolProperty("Enable", true, "Enable/disable the CoM display",
-                       com_category_, SLOT(updateCoMEnable()), this);
+      new BoolProperty("Enable", true, "Enable/disable the CoM display", com_category_, SLOT(updateCoMEnable()), this);
   com_style_property_ =
-      new EnumProperty("Line Style", "Billboards",
-                       "The rendering operation to use to draw the grid lines.",
+      new EnumProperty("Line Style", "Billboards", "The rendering operation to use to draw the grid lines.",
                        com_category_, SLOT(updateCoMStyle()), this);
   com_style_property_->addOption("Billboards", BILLBOARDS);
   com_style_property_->addOption("Lines", LINES);
   com_style_property_->addOption("Points", POINTS);
-  com_line_width_property_ =
-      new FloatProperty("Line Width", 0.01,
-                        "The width, in meters, of each path line. "
-                        "Only works with the 'Billboards' and 'Points' style.",
-                        com_category_, SLOT(updateCoMLineProperties()), this);
+  com_line_width_property_ = new FloatProperty("Line Width", 0.01,
+                                               "The width, in meters, of each path line. "
+                                               "Only works with the 'Billboards' and 'Points' style.",
+                                               com_category_, SLOT(updateCoMLineProperties()), this);
   com_line_width_property_->setMin(0.001);
   com_line_width_property_->show();
-  com_color_property_ = new ColorProperty(
-      "Line Color", QColor(0, 85, 255), "Color to draw the path.",
-      com_category_, SLOT(updateCoMLineProperties()), this);
-  com_scale_property_ = new FloatProperty(
-      "Axes Scale", 1.0, "The scale of the axes that describe the orientation.",
-      com_category_, SLOT(updateCoMLineProperties()), this);
-  com_alpha_property_ = new FloatProperty(
-      "Alpha", 1.0, "Amount of transparency to apply to the trajectory.",
-      com_category_, SLOT(updateCoMLineProperties()), this);
+  com_color_property_ = new ColorProperty("Line Color", QColor(0, 85, 255), "Color to draw the path.", com_category_,
+                                          SLOT(updateCoMLineProperties()), this);
+  com_scale_property_ = new FloatProperty("Axes Scale", 1.0, "The scale of the axes that describe the orientation.",
+                                          com_category_, SLOT(updateCoMLineProperties()), this);
+  com_alpha_property_ = new FloatProperty("Alpha", 1.0, "Amount of transparency to apply to the trajectory.",
+                                          com_category_, SLOT(updateCoMLineProperties()), this);
   com_alpha_property_->setMin(0);
   com_alpha_property_->setMax(1);
 
   // End-effector trajectory properties
-  contact_enable_property_ =
-      new BoolProperty("Enable", true, "Enable/disable the Contact display",
-                       contact_category_, SLOT(updateContactEnable()), this);
+  contact_enable_property_ = new BoolProperty("Enable", true, "Enable/disable the Contact display", contact_category_,
+                                              SLOT(updateContactEnable()), this);
   contact_style_property_ =
-      new EnumProperty("Line Style", "Billboards",
-                       "The rendering operation to use to draw the grid lines.",
+      new EnumProperty("Line Style", "Billboards", "The rendering operation to use to draw the grid lines.",
                        contact_category_, SLOT(updateContactStyle()), this);
   contact_style_property_->addOption("Billboards", BILLBOARDS);
   contact_style_property_->addOption("Lines", LINES);
   contact_style_property_->addOption("Points", POINTS);
-  contact_line_width_property_ = new FloatProperty(
-      "Line Width", 0.01,
-      "The width, in meters, of each trajectory line. "
-      "Only works with the 'Billboards' and 'Points' style.",
-      contact_category_, SLOT(updateContactLineProperties()), this);
+  contact_line_width_property_ = new FloatProperty("Line Width", 0.01,
+                                                   "The width, in meters, of each trajectory line. "
+                                                   "Only works with the 'Billboards' and 'Points' style.",
+                                                   contact_category_, SLOT(updateContactLineProperties()), this);
   contact_line_width_property_->setMin(0.001);
   contact_line_width_property_->show();
-  contact_color_property_ = new ColorProperty(
-      "Line Color", QColor(255, 0, 127), "Color to draw the trajectory.",
-      contact_category_, SLOT(updateContactLineProperties()), this);
-  contact_scale_property_ = new FloatProperty(
-      "Axes Scale", 1.0, "The scale of the axes that describe the orientation.",
-      contact_category_, SLOT(updateContactLineProperties()), this);
-  contact_alpha_property_ = new FloatProperty(
-      "Alpha", 1.0, "Amount of transparency to apply to the trajectory.",
-      contact_category_, SLOT(updateContactLineProperties()), this);
+  contact_color_property_ = new ColorProperty("Line Color", QColor(255, 0, 127), "Color to draw the trajectory.",
+                                              contact_category_, SLOT(updateContactLineProperties()), this);
+  contact_scale_property_ =
+      new FloatProperty("Axes Scale", 1.0, "The scale of the axes that describe the orientation.", contact_category_,
+                        SLOT(updateContactLineProperties()), this);
+  contact_alpha_property_ = new FloatProperty("Alpha", 1.0, "Amount of transparency to apply to the trajectory.",
+                                              contact_category_, SLOT(updateContactLineProperties()), this);
   contact_alpha_property_->setMin(0);
   contact_alpha_property_->setMax(1);
 }
@@ -147,8 +128,7 @@ WholeBodyTrajectoryDisplay::~WholeBodyTrajectoryDisplay() {
 
 void WholeBodyTrajectoryDisplay::onInitialize() {
   MFDClass::onInitialize();
-  robot_.reset(new rviz::Robot(scene_node_, context_,
-                               "Robot: " + getName().toStdString(), this));
+  robot_.reset(new rviz::Robot(scene_node_, context_, "Robot: " + getName().toStdString(), this));
   updateRobotVisualVisible();
   updateRobotCollisionVisible();
   updateRobotAlpha();
@@ -191,21 +171,21 @@ void WholeBodyTrajectoryDisplay::reset() { MFDClass::reset(); }
 void WholeBodyTrajectoryDisplay::updateCoMStyle() {
   LineStyle style = (LineStyle)com_style_property_->getOptionInt();
   switch (style) {
-  case BILLBOARDS:
-    com_line_width_property_->show();
-    com_manual_object_.reset();
-    com_points_.clear();
-    break;
-  case LINES:
-    com_line_width_property_->hide();
-    com_billboard_line_.reset();
-    com_points_.clear();
-    break;
-  case POINTS:
-    com_line_width_property_->show();
-    com_manual_object_.reset();
-    com_billboard_line_.reset();
-    break;
+    case BILLBOARDS:
+      com_line_width_property_->show();
+      com_manual_object_.reset();
+      com_points_.clear();
+      break;
+    case LINES:
+      com_line_width_property_->hide();
+      com_billboard_line_.reset();
+      com_points_.clear();
+      break;
+    case POINTS:
+      com_line_width_property_->show();
+      com_manual_object_.reset();
+      com_billboard_line_.reset();
+      break;
   }
   if (msg_ != nullptr) {
     processCoMTrajectory();
@@ -213,8 +193,7 @@ void WholeBodyTrajectoryDisplay::updateCoMStyle() {
 }
 
 void WholeBodyTrajectoryDisplay::updateRobotDescription() {
-  if (isEnabled())
-    loadRobotModel();
+  if (isEnabled()) loadRobotModel();
 }
 
 void WholeBodyTrajectoryDisplay::updateRobotVisualVisible() {
@@ -223,8 +202,7 @@ void WholeBodyTrajectoryDisplay::updateRobotVisualVisible() {
 }
 
 void WholeBodyTrajectoryDisplay::updateRobotCollisionVisible() {
-  robot_->setCollisionVisible(
-      robot_collision_enabled_property_->getValue().toBool());
+  robot_->setCollisionVisible(robot_collision_enabled_property_->getValue().toBool());
   context_->queueRender();
 }
 
@@ -248,8 +226,7 @@ void WholeBodyTrajectoryDisplay::updateForceArrowGeometry() {
   const float &head_length = force_head_length_property_->getFloat();
   const float &head_radius = force_head_radius_property_->getFloat();
   for (size_t i = 0; i < force_visual_.size(); ++i) {
-    force_visual_[i]->setProperties(shaft_length, shaft_radius, head_length,
-                                    head_radius);
+    force_visual_[i]->setProperties(shaft_length, shaft_radius, head_length, head_radius);
   }
   context_->queueRender();
 }
@@ -284,8 +261,7 @@ void WholeBodyTrajectoryDisplay::updateContactEnable() {
     }
     for (std::size_t i = 0; i < contact_points_.size(); ++i) {
       std::size_t n_elems = contact_points_[i].size();
-      for (std::size_t j = 0; j < n_elems; ++j)
-        contact_points_[i][j].reset();
+      for (std::size_t j = 0; j < n_elems; ++j) contact_points_[i][j].reset();
       contact_points_[i].clear();
     }
   }
@@ -324,8 +300,7 @@ void WholeBodyTrajectoryDisplay::updateCoMLineProperties() {
     }
   } else if (style == LINES) {
     // we have to process again the base trajectory
-    if (msg_ != nullptr)
-      processCoMTrajectory();
+    if (msg_ != nullptr) processCoMTrajectory();
   } else {
     std::size_t n_points = com_points_.size();
     for (std::size_t i = 0; i < n_points; ++i) {
@@ -357,36 +332,34 @@ void WholeBodyTrajectoryDisplay::updateContactStyle() {
   std::size_t n_contacts = contact_billboard_line_.size();
   std::size_t n_points = contact_points_.size();
   switch (style) {
-  case BILLBOARDS:
-    contact_line_width_property_->show();
-    for (std::size_t i = 0; i < n_contacts; ++i) {
-      contact_manual_object_[i].reset();
-    }
-    for (std::size_t i = 0; i < n_points; ++i) {
-      std::size_t n_elems = contact_points_[i].size();
-      for (std::size_t j = 0; j < n_elems; ++j)
-        contact_points_[i][j].reset();
-      contact_points_[i].clear();
-    }
-    break;
-  case LINES:
-    contact_line_width_property_->hide();
-    for (std::size_t i = 0; i < n_contacts; ++i) {
-      contact_billboard_line_[i].reset();
-    }
-    for (std::size_t i = 0; i < n_points; ++i) {
-      std::size_t n_elems = contact_points_[i].size();
-      for (std::size_t j = 0; j < n_elems; ++j)
-        contact_points_[i][j].reset();
-      contact_points_[i].clear();
-    }
-    break;
-  case POINTS:
-    contact_line_width_property_->show();
-    for (std::size_t i = 0; i < n_contacts; ++i) {
-      contact_manual_object_[i].reset();
-      contact_billboard_line_[i].reset();
-    }
+    case BILLBOARDS:
+      contact_line_width_property_->show();
+      for (std::size_t i = 0; i < n_contacts; ++i) {
+        contact_manual_object_[i].reset();
+      }
+      for (std::size_t i = 0; i < n_points; ++i) {
+        std::size_t n_elems = contact_points_[i].size();
+        for (std::size_t j = 0; j < n_elems; ++j) contact_points_[i][j].reset();
+        contact_points_[i].clear();
+      }
+      break;
+    case LINES:
+      contact_line_width_property_->hide();
+      for (std::size_t i = 0; i < n_contacts; ++i) {
+        contact_billboard_line_[i].reset();
+      }
+      for (std::size_t i = 0; i < n_points; ++i) {
+        std::size_t n_elems = contact_points_[i].size();
+        for (std::size_t j = 0; j < n_elems; ++j) contact_points_[i][j].reset();
+        contact_points_[i].clear();
+      }
+      break;
+    case POINTS:
+      contact_line_width_property_->show();
+      for (std::size_t i = 0; i < n_contacts; ++i) {
+        contact_manual_object_[i].reset();
+        contact_billboard_line_[i].reset();
+      }
   }
   if (msg_ != nullptr) {
     processContactTrajectory();
@@ -428,8 +401,7 @@ void WholeBodyTrajectoryDisplay::updateContactLineProperties() {
     }
   } else if (style == LINES) {
     // we have to process again the contact trajectory
-    if (msg_ != nullptr)
-      processContactTrajectory();
+    if (msg_ != nullptr) processContactTrajectory();
   } else {
     std::size_t n_points = contact_points_.size();
     for (std::size_t i = 0; i < n_points; ++i) {
@@ -459,8 +431,7 @@ void WholeBodyTrajectoryDisplay::updateContactLineProperties() {
   context_->queueRender();
 }
 
-void WholeBodyTrajectoryDisplay::processMessage(
-    const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr &msg) {
+void WholeBodyTrajectoryDisplay::processMessage(const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr &msg) {
   // Updating the message
   msg_ = msg;
   has_new_msg_ = true;
@@ -484,15 +455,13 @@ void WholeBodyTrajectoryDisplay::processTargetPosture() {
   if (target_enable_) {
     Ogre::Quaternion orientation;
     Ogre::Vector3 position;
-    if (!context_->getFrameManager()->getTransform(
-            msg_->header.frame_id, msg_->header.stamp, position, orientation)) {
-      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'",
-                msg_->header.frame_id.c_str(), qPrintable(fixed_frame_));
+    if (!context_->getFrameManager()->getTransform(msg_->header.frame_id, msg_->header.stamp, position, orientation)) {
+      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'", msg_->header.frame_id.c_str(),
+                qPrintable(fixed_frame_));
       return;
     }
 
-    const whole_body_state_msgs::WholeBodyState &state =
-        msg_->trajectory.back();
+    const whole_body_state_msgs::WholeBodyState &state = msg_->trajectory.back();
     Eigen::VectorXd q = Eigen::VectorXd::Zero(model_.nq);
     q(3) = state.centroidal.base_orientation.x;
     q(4) = state.centroidal.base_orientation.y;
@@ -500,36 +469,29 @@ void WholeBodyTrajectoryDisplay::processTargetPosture() {
     q(6) = state.centroidal.base_orientation.w;
     std::size_t n_joints = state.joints.size();
     for (std::size_t j = 0; j < n_joints; ++j) {
-      pinocchio::JointIndex jointId =
-          model_.getJointId(state.joints[j].name) - 2;
+      pinocchio::JointIndex jointId = model_.getJointId(state.joints[j].name) - 2;
       q(jointId + 7) = state.joints[j].position;
     }
     pinocchio::centerOfMass(model_, data_, q);
     q(0) = state.centroidal.com_position.x - data_.com[0](0);
     q(1) = state.centroidal.com_position.y - data_.com[0](1);
     q(2) = state.centroidal.com_position.z - data_.com[0](2);
-    robot_->update(PinocchioLinkUpdater(
-        model_, data_, q,
-        boost::bind(linkUpdaterStatusFunction, _1, _2, _3, this)));
+    robot_->update(PinocchioLinkUpdater(model_, data_, q, boost::bind(linkUpdaterStatusFunction, _1, _2, _3, this)));
 
     size_t n_contacts = state.contacts.size();
     force_visual_.clear();
     for (size_t i = 0; i < n_contacts; ++i) {
       const whole_body_state_msgs::ContactState &contact = state.contacts[i];
       // Getting the contact position
-      Ogre::Vector3 contact_pos(contact.pose.position.x,
-                                contact.pose.position.y,
-                                contact.pose.position.z);
+      Ogre::Vector3 contact_pos(contact.pose.position.x, contact.pose.position.y, contact.pose.position.z);
       // Getting the force direction
       Eigen::Vector3d for_ref_dir = -Eigen::Vector3d::UnitZ();
-      Eigen::Vector3d for_dir(contact.wrench.force.x, contact.wrench.force.y,
-                              contact.wrench.force.z);
-      if (for_dir.norm() > 0. && std::isfinite(contact_pos.x) &&
-          std::isfinite(contact_pos.y) && std::isfinite(contact_pos.z)) {
+      Eigen::Vector3d for_dir(contact.wrench.force.x, contact.wrench.force.y, contact.wrench.force.z);
+      if (for_dir.norm() > 0. && std::isfinite(contact_pos.x) && std::isfinite(contact_pos.y) &&
+          std::isfinite(contact_pos.z)) {
         Eigen::Quaterniond for_q;
         for_q.setFromTwoVectors(for_ref_dir, for_dir);
-        Ogre::Quaternion contact_for_orientation(for_q.w(), for_q.x(),
-                                                 for_q.y(), for_q.z());
+        Ogre::Quaternion contact_for_orientation(for_q.w(), for_q.x(), for_q.y(), for_q.z());
         // We are keeping a vector of visual pointers. This creates the next
         // one and stores it in the vector
         boost::shared_ptr<ArrowVisual> arrow;
@@ -541,16 +503,14 @@ void WholeBodyTrajectoryDisplay::processTargetPosture() {
         Ogre::ColourValue color = force_color_property_->getOgreColor();
         color.a = force_alpha_property_->getFloat();
         arrow->setColor(color.r, color.g, color.b, color.a);
-        const float &shaft_length =
-            force_shaft_length_property_->getFloat() * for_dir.norm() / weight_;
+        const float &shaft_length = force_shaft_length_property_->getFloat() * for_dir.norm() / weight_;
         const float &shaft_radius = force_shaft_radius_property_->getFloat();
         const float &head_length = force_head_length_property_->getFloat();
         const float &head_radius = force_head_radius_property_->getFloat();
-        arrow->setProperties(shaft_length, shaft_radius, head_length,
-                             head_radius);
+        arrow->setProperties(shaft_length, shaft_radius, head_length, head_radius);
         // And send it to the end of the vector
-        if (std::isfinite(shaft_length) && std::isfinite(shaft_radius) &&
-            std::isfinite(head_length) && std::isfinite(head_radius)) {
+        if (std::isfinite(shaft_length) && std::isfinite(shaft_radius) && std::isfinite(head_length) &&
+            std::isfinite(head_radius)) {
           force_visual_.push_back(arrow);
         }
       }
@@ -563,10 +523,9 @@ void WholeBodyTrajectoryDisplay::processCoMTrajectory() {
   if (com_enable_) {
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;
-    if (!context_->getFrameManager()->getTransform(msg_->header, position,
-                                                   orientation)) {
-      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'",
-                msg_->header.frame_id.c_str(), qPrintable(fixed_frame_));
+    if (!context_->getFrameManager()->getTransform(msg_->header, position, orientation)) {
+      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'", msg_->header.frame_id.c_str(),
+                qPrintable(fixed_frame_));
     }
     Ogre::Matrix4 transform(orientation);
     transform.setTrans(position);
@@ -595,20 +554,15 @@ void WholeBodyTrajectoryDisplay::processCoMTrajectory() {
       base_orientation.z = state.centroidal.base_orientation.z;
       base_orientation.w = state.centroidal.base_orientation.w;
       // sanity checks
-      if (!(std::isfinite(com_position.x) && std::isfinite(com_position.y) &&
-            std::isfinite(com_position.z))) {
-        std::cerr << "CoM position is not finite, resetting to zero"
-                  << std::endl;
+      if (!(std::isfinite(com_position.x) && std::isfinite(com_position.y) && std::isfinite(com_position.z))) {
+        std::cerr << "CoM position is not finite, resetting to zero" << std::endl;
         com_position.x = 0.0;
         com_position.y = 0.0;
         com_position.z = 0.0;
       }
-      if (!(std::isfinite(base_orientation.x) &&
-            std::isfinite(base_orientation.y) &&
-            std::isfinite(base_orientation.z) &&
-            std::isfinite(base_orientation.w))) {
-        std::cerr << "Body orientation is not finite, resetting to [0 0 0 1]"
-                  << std::endl;
+      if (!(std::isfinite(base_orientation.x) && std::isfinite(base_orientation.y) &&
+            std::isfinite(base_orientation.z) && std::isfinite(base_orientation.w))) {
+        std::cerr << "Body orientation is not finite, resetting to [0 0 0 1]" << std::endl;
         base_orientation.x = 0.;
         base_orientation.y = 0.;
         base_orientation.z = 0.;
@@ -620,50 +574,45 @@ void WholeBodyTrajectoryDisplay::processCoMTrajectory() {
         pushBackCoMAxes(point_position, base_orientation * orientation);
       }
       switch (base_style) {
-      case BILLBOARDS: {
-        // Getting the base line width
-        if (i == 0) {
+        case BILLBOARDS: {
+          // Getting the base line width
+          if (i == 0) {
+            float base_line_width = com_line_width_property_->getFloat();
+            com_billboard_line_.reset(new rviz::BillboardLine(scene_manager_, scene_node_));
+            com_billboard_line_->setNumLines(1);
+            com_billboard_line_->setMaxPointsPerLine(n_points);
+            com_billboard_line_->setLineWidth(base_line_width);
+          }
+          com_billboard_line_->addPoint(point_position, base_color);
+        } break;
+        case LINES: {
+          if (i == 0) {
+            com_manual_object_.reset(scene_manager_->createManualObject());
+            com_manual_object_->setDynamic(true);
+            scene_node_->attachObject(com_manual_object_.get());
+            com_manual_object_->estimateVertexCount(n_points);
+            com_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP);
+          }
+          com_manual_object_->position(point_position.x, point_position.y, point_position.z);
+          com_manual_object_->colour(base_color);
+        } break;
+        case POINTS: {
+          if (i == 0) {
+            com_points_.clear();
+          }
           float base_line_width = com_line_width_property_->getFloat();
-          com_billboard_line_.reset(
-              new rviz::BillboardLine(scene_manager_, scene_node_));
-          com_billboard_line_->setNumLines(1);
-          com_billboard_line_->setMaxPointsPerLine(n_points);
-          com_billboard_line_->setLineWidth(base_line_width);
-        }
-        com_billboard_line_->addPoint(point_position, base_color);
-      } break;
-      case LINES: {
-        if (i == 0) {
-          com_manual_object_.reset(scene_manager_->createManualObject());
-          com_manual_object_->setDynamic(true);
-          scene_node_->attachObject(com_manual_object_.get());
-          com_manual_object_->estimateVertexCount(n_points);
-          com_manual_object_->begin("BaseWhiteNoLighting",
-                                    Ogre::RenderOperation::OT_LINE_STRIP);
-        }
-        com_manual_object_->position(point_position.x, point_position.y,
-                                     point_position.z);
-        com_manual_object_->colour(base_color);
-      } break;
-      case POINTS: {
-        if (i == 0) {
-          com_points_.clear();
-        }
-        float base_line_width = com_line_width_property_->getFloat();
-        // We are keeping a vector of CoM visual pointers. This creates the next
-        // one and stores it in the vector
-        boost::shared_ptr<PointVisual> point_visual;
-        point_visual.reset(
-            new PointVisual(context_->getSceneManager(), scene_node_));
-        point_visual->setColor(base_color.r, base_color.g, base_color.b,
-                               base_color.a);
-        point_visual->setRadius(base_line_width);
-        point_visual->setPoint(com_position);
-        point_visual->setFramePosition(position);
-        point_visual->setFrameOrientation(orientation);
-        // And send it to the end of the vector
-        com_points_.push_back(point_visual);
-      } break;
+          // We are keeping a vector of CoM visual pointers. This creates the next
+          // one and stores it in the vector
+          boost::shared_ptr<PointVisual> point_visual;
+          point_visual.reset(new PointVisual(context_->getSceneManager(), scene_node_));
+          point_visual->setColor(base_color.r, base_color.g, base_color.b, base_color.a);
+          point_visual->setRadius(base_line_width);
+          point_visual->setPoint(com_position);
+          point_visual->setFramePosition(position);
+          point_visual->setFrameOrientation(orientation);
+          // And send it to the end of the vector
+          com_points_.push_back(point_visual);
+        } break;
       }
     }
     if (base_style == LINES) {
@@ -677,10 +626,9 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
     // Lookup transform into fixed frame
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;
-    if (!context_->getFrameManager()->getTransform(msg_->header, position,
-                                                   orientation)) {
-      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'",
-                msg_->header.frame_id.c_str(), qPrintable(fixed_frame_));
+    if (!context_->getFrameManager()->getTransform(msg_->header, position, orientation)) {
+      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'", msg_->header.frame_id.c_str(),
+                qPrintable(fixed_frame_));
     }
     Ogre::Matrix4 transform(orientation);
     transform.setTrans(position);
@@ -688,8 +636,7 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
     // Visualization of the end-effector trajectory
     // Getting the end-effector trajectory style
     uint32_t n_points = msg_->trajectory.size();
-    LineStyle contact_style =
-        (LineStyle)contact_style_property_->getOptionInt();
+    LineStyle contact_style = (LineStyle)contact_style_property_->getOptionInt();
 
     // Getting the end-effector trajectory color
     Ogre::ColourValue contact_color = contact_color_property_->getOgreColor();
@@ -702,10 +649,8 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
       const whole_body_state_msgs::WholeBodyState &state = msg_->trajectory[i];
       std::size_t n_contacts = state.contacts.size();
       for (std::size_t k = 0; k < n_contacts; ++k) {
-        whole_body_state_msgs::ContactState contact =
-            msg_->trajectory[i].contacts[k];
-        if (contact_traj_id.find(contact.name) ==
-            contact_traj_id.end()) { // a new swing trajectory
+        whole_body_state_msgs::ContactState contact = msg_->trajectory[i].contacts[k];
+        if (contact_traj_id.find(contact.name) == contact_traj_id.end()) {  // a new swing trajectory
           contact_traj_id[contact.name] = n_traj;
           // Incrementing the counter (id) of swing trajectories
           ++n_traj;
@@ -719,20 +664,20 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
     std::map<std::size_t, std::size_t> contact_vec_id;
     float contact_line_width = contact_line_width_property_->getFloat();
     switch (contact_style) {
-    case BILLBOARDS: {
-      // Getting the end-effector line width
-      contact_billboard_line_.clear();
-      contact_billboard_line_.resize(n_traj);
-    } break;
-    case LINES: {
-      contact_manual_object_.clear();
-      contact_manual_object_.resize(n_traj);
-    } break;
-    case POINTS: {
-      // Getting the end-effector line width
-      contact_points_.clear();
-      contact_points_.resize(n_points);
-    } break;
+      case BILLBOARDS: {
+        // Getting the end-effector line width
+        contact_billboard_line_.clear();
+        contact_billboard_line_.resize(n_traj);
+      } break;
+      case LINES: {
+        contact_manual_object_.clear();
+        contact_manual_object_.resize(n_traj);
+      } break;
+      case POINTS: {
+        // Getting the end-effector line width
+        contact_points_.clear();
+        contact_points_.resize(n_points);
+      } break;
     }
 
     std::size_t traj_id = 0;
@@ -741,37 +686,32 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
       std::size_t n_contacts = state.contacts.size();
       for (std::size_t k = 0; k < n_contacts; ++k) {
         const whole_body_state_msgs::ContactState &contact = state.contacts[k];
-        if (contact_traj_id.find(contact.name) ==
-            contact_traj_id.end()) { // a new swing trajectory
+        if (contact_traj_id.find(contact.name) == contact_traj_id.end()) {  // a new swing trajectory
           contact_traj_id[contact.name] = traj_id;
           contact_vec_id[traj_id] = k;
           switch (contact_style) {
-          case BILLBOARDS: {
-            contact_billboard_line_[traj_id].reset(
-                new rviz::BillboardLine(scene_manager_, scene_node_));
-            contact_billboard_line_[traj_id]->setNumLines(1);
-            contact_billboard_line_[traj_id]->setMaxPointsPerLine(n_points);
-            contact_billboard_line_[traj_id]->setLineWidth(contact_line_width);
-          } break;
-          case LINES: {
-            contact_manual_object_[traj_id].reset(
-                scene_manager_->createManualObject());
-            contact_manual_object_[traj_id]->setDynamic(true);
-            scene_node_->attachObject(contact_manual_object_[traj_id].get());
-            contact_manual_object_[traj_id]->estimateVertexCount(n_points);
-            contact_manual_object_[traj_id]->begin(
-                "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP);
-          } break;
-          case POINTS: {
-            // do nothing
-          } break;
+            case BILLBOARDS: {
+              contact_billboard_line_[traj_id].reset(new rviz::BillboardLine(scene_manager_, scene_node_));
+              contact_billboard_line_[traj_id]->setNumLines(1);
+              contact_billboard_line_[traj_id]->setMaxPointsPerLine(n_points);
+              contact_billboard_line_[traj_id]->setLineWidth(contact_line_width);
+            } break;
+            case LINES: {
+              contact_manual_object_[traj_id].reset(scene_manager_->createManualObject());
+              contact_manual_object_[traj_id]->setDynamic(true);
+              scene_node_->attachObject(contact_manual_object_[traj_id].get());
+              contact_manual_object_[traj_id]->estimateVertexCount(n_points);
+              contact_manual_object_[traj_id]->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP);
+            } break;
+            case POINTS: {
+              // do nothing
+            } break;
           }
           // Incrementing the counter (id) of swing trajectories
           ++traj_id;
         } else {
           std::size_t swing_idx = contact_traj_id.find(contact.name)->second;
-          if (k != contact_vec_id.find(swing_idx)
-                       ->second) { // change the vector index
+          if (k != contact_vec_id.find(swing_idx)->second) {  // change the vector index
             contact_vec_id[swing_idx] = k;
           }
         }
@@ -783,14 +723,12 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
         contact_points_[i].clear();
         contact_points_[i].resize(n_contacts);
       }
-      for (std::map<std::string, std::size_t>::iterator traj_it =
-               contact_traj_id.begin();
+      for (std::map<std::string, std::size_t>::iterator traj_it = contact_traj_id.begin();
            traj_it != contact_traj_id.end(); ++traj_it) {
         std::size_t traj_id = traj_it->second;
         std::size_t id = contact_vec_id.find(traj_id)->second;
         if (id < n_contacts) {
-          const whole_body_state_msgs::ContactState &contact =
-              state.contacts[id];
+          const whole_body_state_msgs::ContactState &contact = state.contacts[id];
           Ogre::Vector3 contact_position;
           Ogre::Quaternion contact_orientation;
           contact_position.x = contact.pose.position.x;
@@ -801,22 +739,16 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
           contact_orientation.z = contact.pose.orientation.z;
           contact_orientation.w = contact.pose.orientation.w;
           // sanity check orientation
-          if (!(std::isfinite(contact_position.x) &&
-                std::isfinite(contact_position.y) &&
+          if (!(std::isfinite(contact_position.x) && std::isfinite(contact_position.y) &&
                 std::isfinite(contact_position.z))) {
-            std::cerr << "Contact trajectory is not finite, resetting to zero!"
-                      << std::endl;
+            std::cerr << "Contact trajectory is not finite, resetting to zero!" << std::endl;
             contact_position.x = 0.0;
             contact_position.y = 0.0;
             contact_position.z = 0.0;
           }
-          if (!(std::isfinite(contact_orientation.x) &&
-                std::isfinite(contact_orientation.y) &&
-                std::isfinite(contact_orientation.z) &&
-                std::isfinite(contact_orientation.w))) {
-            std::cerr
-                << "Contact orientation is not finite, resetting to [0 0 0 1]"
-                << std::endl;
+          if (!(std::isfinite(contact_orientation.x) && std::isfinite(contact_orientation.y) &&
+                std::isfinite(contact_orientation.z) && std::isfinite(contact_orientation.w))) {
+            std::cerr << "Contact orientation is not finite, resetting to [0 0 0 1]" << std::endl;
             contact_orientation.x = 0.;
             contact_orientation.y = 0.;
             contact_orientation.z = 0.;
@@ -824,31 +756,26 @@ void WholeBodyTrajectoryDisplay::processContactTrajectory() {
           }
           Ogre::Vector3 point_position = transform * contact_position;
           if (contact_axes_enable_) {
-            pushBackContactAxes(point_position,
-                                contact_orientation * orientation);
+            pushBackContactAxes(point_position, contact_orientation * orientation);
           }
           switch (contact_style) {
-          case BILLBOARDS: {
-            contact_billboard_line_[traj_id]->addPoint(point_position,
-                                                       contact_color);
-          } break;
-          case LINES: {
-            contact_manual_object_[traj_id]->position(
-                point_position.x, point_position.y, point_position.z);
-            contact_manual_object_[traj_id]->colour(contact_color);
-          } break;
-          case POINTS: {
-            contact_points_[i][contact_idx].reset(
-                new PointVisual(context_->getSceneManager(), scene_node_));
-            contact_points_[i][contact_idx]->setColor(
-                contact_color.r, contact_color.g, contact_color.b,
-                contact_color.a);
-            contact_points_[i][contact_idx]->setRadius(contact_line_width);
-            contact_points_[i][contact_idx]->setPoint(point_position);
-            contact_points_[i][contact_idx]->setFramePosition(position);
-            contact_points_[i][contact_idx]->setFrameOrientation(orientation);
-            ++contact_idx;
-          } break;
+            case BILLBOARDS: {
+              contact_billboard_line_[traj_id]->addPoint(point_position, contact_color);
+            } break;
+            case LINES: {
+              contact_manual_object_[traj_id]->position(point_position.x, point_position.y, point_position.z);
+              contact_manual_object_[traj_id]->colour(contact_color);
+            } break;
+            case POINTS: {
+              contact_points_[i][contact_idx].reset(new PointVisual(context_->getSceneManager(), scene_node_));
+              contact_points_[i][contact_idx]->setColor(contact_color.r, contact_color.g, contact_color.b,
+                                                        contact_color.a);
+              contact_points_[i][contact_idx]->setRadius(contact_line_width);
+              contact_points_[i][contact_idx]->setPoint(point_position);
+              contact_points_[i][contact_idx]->setFramePosition(position);
+              contact_points_[i][contact_idx]->setFrameOrientation(orientation);
+              ++contact_idx;
+            } break;
           }
         }
       }
@@ -867,11 +794,9 @@ void WholeBodyTrajectoryDisplay::loadRobotModel() {
   clearStatuses();
   context_->queueRender();
   std::string content;
-  if (!update_nh_.getParam(robot_description_property_->getStdString(),
-                           content)) {
+  if (!update_nh_.getParam(robot_description_property_->getStdString(), content)) {
     std::string loc;
-    if (update_nh_.searchParam(robot_description_property_->getStdString(),
-                               loc)) {
+    if (update_nh_.searchParam(robot_description_property_->getStdString(), loc)) {
       update_nh_.getParam(loc, content);
     } else {
       clearRobotModel();
@@ -899,14 +824,12 @@ void WholeBodyTrajectoryDisplay::loadRobotModel() {
     return;
   }
   try {
-    pinocchio::urdf::buildModelFromXML(
-        robot_description_, pinocchio::JointModelFreeFlyer(), model_);
+    pinocchio::urdf::buildModelFromXML(robot_description_, pinocchio::JointModelFreeFlyer(), model_);
   } catch (const std::invalid_argument &e) {
     std::string error_msg = "Failed to instantiate model: ";
     error_msg += e.what();
-    setStatus(StatusProperty::Error, "Pinocchio-URDFParser",
-              QString::fromStdString(error_msg));
-    ROS_ERROR_STREAM(error_msg); // This message is potentially quite detailed.
+    setStatus(StatusProperty::Error, "Pinocchio-URDFParser", QString::fromStdString(error_msg));
+    ROS_ERROR_STREAM(error_msg);  // This message is potentially quite detailed.
     return;
   }
   data_ = pinocchio::Data(model_);
@@ -939,9 +862,8 @@ void WholeBodyTrajectoryDisplay::destroyObjects() {
   contact_axes_.clear();
 }
 
-void WholeBodyTrajectoryDisplay::pushBackCoMAxes(
-    const Ogre::Vector3 &axes_position,
-    const Ogre::Quaternion &axes_orientation) {
+void WholeBodyTrajectoryDisplay::pushBackCoMAxes(const Ogre::Vector3 &axes_position,
+                                                 const Ogre::Quaternion &axes_orientation) {
   // We are keeping a vector of CoM frame pointers. This creates the next
   // one and stores it in the vector
   float scale = com_scale_property_->getFloat();
@@ -968,9 +890,8 @@ void WholeBodyTrajectoryDisplay::pushBackCoMAxes(
   }
 }
 
-void WholeBodyTrajectoryDisplay::pushBackContactAxes(
-    const Ogre::Vector3 &axes_position,
-    const Ogre::Quaternion &axes_orientation) {
+void WholeBodyTrajectoryDisplay::pushBackContactAxes(const Ogre::Vector3 &axes_position,
+                                                     const Ogre::Quaternion &axes_orientation) {
   // We are keeping a vector of contact frame pointers. This creates the next
   // one and stores it in the vector
   float scale = contact_scale_property_->getFloat();
@@ -997,8 +918,7 @@ void WholeBodyTrajectoryDisplay::pushBackContactAxes(
   }
 }
 
-} // namespace whole_body_state_rviz_plugin
+}  // namespace whole_body_state_rviz_plugin
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_EXPORT_CLASS(whole_body_state_rviz_plugin::WholeBodyTrajectoryDisplay,
-                       rviz::Display)
+PLUGINLIB_EXPORT_CLASS(whole_body_state_rviz_plugin::WholeBodyTrajectoryDisplay, rviz::Display)

--- a/src/WholeBodyTrajectoryDisplay.cpp
+++ b/src/WholeBodyTrajectoryDisplay.cpp
@@ -476,6 +476,8 @@ void WholeBodyTrajectoryDisplay::processTargetPosture() {
     q(0) = state.centroidal.com_position.x - data_.com[0](0);
     q(1) = state.centroidal.com_position.y - data_.com[0](1);
     q(2) = state.centroidal.com_position.z - data_.com[0](2);
+    robot_->setPosition(position);
+    robot_->setOrientation(orientation);
     robot_->update(PinocchioLinkUpdater(model_, data_, q, boost::bind(linkUpdaterStatusFunction, _1, _2, _3, this)));
 
     size_t n_contacts = state.contacts.size();


### PR DESCRIPTION
This PRs fixed a couple of issues that were happening when the user is defining a fixed frame in Rviz that is different to the message frame id.