### PR TITLE
Fix plugin_description.xml installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,5 +103,5 @@ TARGET_LINK_LIBRARIES(${PROJECT_NAME}  ${QT_LIBRARIES}
                                        pinocchio::pinocchio)
 #TARGET_COMPILE_OPTIONS(${PROJECT_NAME} PRIVATE -Wno-ignored-attributes)  # Silence Eigen::Tensor warnings
 
-INSTALL(FILES ${CMAKE_SOURCE_DIR}/plugin_description.xml DESTINATION share/${PROJECT_NAME})
+INSTALL(FILES plugin_description.xml DESTINATION share/${PROJECT_NAME})
 INSTALL(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)


### PR DESCRIPTION
This PR fixes the path to `plugin_description.xml` because it's not found when you try to install it.

The steps that I followed were the following:

```bash
source /opt/ros/${ROS_DISTRO}/setup.bash
catkin_make -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/ros/${ROS_DISTRO}
cd build
sudo make install
```