### PR TITLE
Fix issue where the GRF and friction cones were not coinciding with CoP

### DIFF
--- a/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
+++ b/include/whole_body_state_rviz_plugin/WholeBodyStateDisplay.h
@@ -247,7 +247,6 @@ class WholeBodyStateDisplay : public rviz::MessageFilterDisplay<whole_body_state
   bool com_enable_;
   bool zmp_enable_;
   bool cop_enable_;
-  std::vector<Ogre::Vector3> cop_pos_;  //!< Stores locations of the foot center of pressures
   bool icp_enable_;
   bool cmp_enable_;
   bool grf_enable_;


### PR DESCRIPTION
I noticed a bug in my recent changes where the GRFs and friction cones were not aligning with the contact CoPs. See below for a before and after video. Before, the arrows and cones do not follow the orange spheres. After, they do. The code changes have a nice bonus of slightly reducing code complexity, which is nice.

@cmastalli 

https://user-images.githubusercontent.com/13335715/220445258-40fb60dc-651d-4699-8ff3-f4b5b83aab34.mp4
https://user-images.githubusercontent.com/13335715/220445265-ff33b3cf-f63c-4b73-9cf6-7ed6b8bc4dae.mp4